### PR TITLE
Fixes CSS scopes

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -13,3 +13,25 @@
     >.
   </p>
 </section>
+
+<style>
+  section {
+    background-color: var(--primary-colour);
+    padding: 1em 1em 0 1em;
+  }
+
+  p:first-child() {
+    margin-top: 0;
+  }
+
+  p:last-child() {
+    margin-bottom: 0;
+  }
+
+  #cursor {
+    display: inline-block;
+    background-color: var(--secondary-colour);
+    color: var(--primary-colour);
+    animation: blinker 1s step-start infinite;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,16 +18,8 @@ import Navigation from '../components/Navigation.astro';
     display: flex;
     flex-direction: column;
 
-    div,
-    #about {
-      padding-inline: 1em;
-    }
-    #about {
-      background-color: blue;
-    }
     div {
-      padding-top: 1em;
-      padding-bottom: 5em;
+      padding: 1em 1em 5em 1em;
       background-image: linear-gradient(to bottom, blue 40%, white);
     }
 
@@ -36,21 +28,20 @@ import Navigation from '../components/Navigation.astro';
       display: inline;
     }
 
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+
     h1,
-    h2,
-    h3 {
+    a,
+    li {
       font-weight: normal;
+      font-size: 1rem;
     }
 
     #about {
       order: -1;
-    }
-
-    #cursor {
-      display: inline-block;
-      background-color: var(--secondary-colour);
-      color: var(--primary-colour);
-      animation: blinker 1s step-start infinite;
     }
   }
 </style>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,7 +1,3 @@
----
-
----
-
 <nav>
   <ul>
     <li>
@@ -29,18 +25,6 @@
   ul,
   li {
     display: inline;
-  }
-
-  nav {
-    font-family: var(--body-mono-fonts);
-    font-size: var(--body-fonts-size);
-    font-weight: normal;
-  }
-
-  ul {
-    padding: 0;
-    list-style-type: none;
-    margin-left: 0.5em;
   }
 
   li:before {

--- a/src/components/Preview.astro
+++ b/src/components/Preview.astro
@@ -13,30 +13,29 @@ const { title, url, pubDate, standfirst } = Astro.props;
 </div>
 
 <style>
-  h1,
-  h2,
-  h3 {
-    font-family: var(--display-serif-fonts);
-    font-size: 3em;
-  }
-
   div {
     display: flex;
     flex-direction: column;
     margin-bottom: 3rem;
 
+    h1,
+    h2 {
+      font-family: var(--display-serif-fonts);
+    }
+
     h1 {
-      margin-top: 0.5rem;
-      margin-bottom: 1rem;
+      font-size: 3rem;
+      margin-block: 0.25em;
     }
 
     p {
-      margin-top: 0;
+      font-family: var(--body-serif-fonts);
     }
 
     time {
       order: -1;
-      font-size: 1rem;
+      font-family: var(--body-mono-fonts);
+      font-size: 0.6em;
     }
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -28,20 +28,6 @@ import Header from '../components/Header.astro';
 
 <style>
   main {
-    background-color: var(--secondary-colour);
-    color: black;
-    font-size: var(--body-fonts-size);
     padding: 3em 1em 1em 1em;
-
-    p {
-      font-family: var(--body-serif-fonts);
-    }
-
-    img,
-    time,
-    iframe {
-      display: block;
-      width: 100%;
-    }
   }
 </style>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,18 +1,20 @@
 :root {
   --primary-colour: blue;
   --secondary-colour: white;
-  --tertiary-colour: white;
+  --tertiary-colour: black;
   --body-mono-fonts: 'IBM Plex Mono', hack, monospace, monospace;
   --body-serif-fonts: 'Garamond', 'Times New Roman', serif;
   --display-serif-fonts: 'Instrument Serif', 'Playfair Display';
   --heading-fonts:
     var(--display-serif-fonts), var(--body-serif-fonts), var(--body-mono-fonts);
   --body-fonts-size: 1.5rem;
+  font-size: var(--body-fonts-size);
 }
 
 body {
   margin: 0;
   padding: 0;
+
   a {
     color: inherit;
   }
@@ -47,11 +49,7 @@ a:hover,
 button:hover,
 ::selection {
   color: var(--primary-colour);
-  background-color: var(--tertiary-colour);
-}
-
-.no-show {
-  display: none;
+  background-color: var(--secondary-colour);
 }
 
 @keyframes blinker {


### PR DESCRIPTION
With many of the features refactored into components, I had some issues with scoped styles.

- Font size is now relative to root, which is defined by a variable set to 1.5em;
- Duplicate rules removed
- Styles moved as close to scope as possible